### PR TITLE
Use S3 for job logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ function runJob(info, callback) {
                 stderr: true,
             }, (err, stream) => {
                 if (ERR(err, callback)) return;
-                const out = byline(stream);
+                const out = byline(stream, { keepEmptyLines: true });
                 out.on('data', (line) => {
                     logger.info(`container> ${line.toString('utf8')}`);
                 });

--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ function uploadResults(info, callback) {
             const params = {
                 Bucket: s3Bucket,
                 Key: `${s3RootKey}/results.json`,
-                Body: new Buffer(JSON.stringify(results), 'binary')
+                Body: new Buffer(JSON.stringify(results, null, '  '), 'binary')
             };
             s3.putObject(params, (err) => {
                 if (ERR(err, callback)) return;

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ function runJob(info, callback) {
                 stderr: true,
             }, (err, stream) => {
                 if (ERR(err, callback)) return;
-                const out = byline(stream, { keepEmptyLines: true });
+                const out = byline(stream);
                 out.on('data', (line) => {
                     logger.info(`container> ${line.toString('utf8')}`);
                 });

--- a/lib/jobLogger.js
+++ b/lib/jobLogger.js
@@ -19,7 +19,8 @@ module.exports = function(options) {
 
     const transports = [
         new (winston.transports.File)({
-            stream: s3LoggerStream
+            stream: s3LoggerStream,
+            json: false
         })
     ];
 

--- a/lib/jobLogger.js
+++ b/lib/jobLogger.js
@@ -1,25 +1,25 @@
 const winston = require('winston');
-const CloudWatchTransport = require('winston-aws-cloudwatch');
+const S3StreamLogger = require('s3-streamlogger').S3StreamLogger;
 
 const globalLogger = require('./logger');
 const config = require('./config').config;
 
 module.exports = function(options) {
     const {
-        groupName,
-        streamName
+        bucket,
+        rootKey
     } = options;
 
+    const s3LoggerStream = new S3StreamLogger({
+        bucket,
+        folder: rootKey,
+        name_format: 'output.log', // No need to rotate, all logs go to same file
+        upload_every: 1000 // Most jobs are short-lived, so push every 1s
+    });
+
     const transports = [
-        new (CloudWatchTransport)({
-            level: 'info',
-            logGroupName: groupName,
-            logStreamName: streamName,
-            createLogGroup: true,
-            createLogStream: true,
-            submissionInterval: 1000,
-            batchSize: 30,
-            awsConfig: config.awsConfig
+        new (winston.transports.File)({
+            stream: s3LoggerStream
         })
     ];
 
@@ -30,7 +30,7 @@ module.exports = function(options) {
     const logger = new (winston.Logger)({ transports });
 
     logger.on('error', (err) => {
-        globalLogger.error(`Error sending logs to ${streamName} in group ${groupName}`);
+        globalLogger.error(`Error sending logs to ${bucket}/${rootKey}/output.log`);
         globalLogger.error(err);
     });
 

--- a/lib/messageSchema.json
+++ b/lib/messageSchema.json
@@ -8,9 +8,8 @@
         "jobId",
         "image",
         "entrypoint",
-        "s3JobsBucket",
-        "s3ResultsBucket",
-        "s3ArchivesBucket"
+        "s3Bucket",
+        "s3RootKey"
     ],
     "properties": {
         "jobId": {
@@ -29,16 +28,12 @@
             "description": "The number of seconds after which the grading job will timeout.",
             "type": "integer"
         },
-        "s3JobsBucket": {
-            "description": "The AWS S3 bucket to fetch this job from.",
+        "s3Bucket": {
+            "description": "The AWS S3 bucket containing this job's files.",
             "type": "string"
         },
-        "s3ResultsBucket": {
-            "description": "The AWS S3 bucket to upload results to.",
-            "type": "string"
-        },
-        "s3ArchivesBucket": {
-            "description": "The AWS S3 bucket to upload the archives for this job to.",
+        "s3RootKey": {
+            "description": "The root key for th job's files.",
             "type": "string"
         },
         "webhookUrl": {

--- a/lib/messageSchema.json
+++ b/lib/messageSchema.json
@@ -14,7 +14,7 @@
     "properties": {
         "jobId": {
             "description": "The unique ID for this job.",
-            "type": "string"
+            "type": ["string", "integer"]
         },
         "image": {
             "description": "The image that this job will be executed in.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,14 +200,16 @@
       "dev": true
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "requires": {
         "lodash": "4.17.4"
       }
     },
     "async-stacktrace": {
-      "version": "https://registry.npmjs.org/async-stacktrace/-/async-stacktrace-0.0.2.tgz",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/async-stacktrace/-/async-stacktrace-0.0.2.tgz",
       "integrity": "sha1-i7uXh+OzjINscpp+nXwIYw210e8="
     },
     "asynckit": {
@@ -2313,6 +2315,11 @@
         }
       }
     },
+    "git-branch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/git-branch/-/git-branch-0.3.0.tgz",
+      "integrity": "sha1-yuU/WZBU0r1Hc+FkVQ9UzF/lPSw="
+    },
     "glob": {
       "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
@@ -2749,7 +2756,7 @@
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
       "dev": true,
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+        "async": "2.5.0",
         "fileset": "2.0.3",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-hook": "1.0.7",
@@ -4218,6 +4225,16 @@
         "rx-lite": "4.0.8"
       }
     },
+    "s3-streamlogger": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/s3-streamlogger/-/s3-streamlogger-1.3.1.tgz",
+      "integrity": "sha1-RJ7Hfl0PPn00PB+3DA3oKgaEAJY=",
+      "requires": {
+        "aws-sdk": "2.134.0",
+        "git-branch": "0.3.0",
+        "strftime": "0.8.4"
+      }
+    },
     "safe-buffer": {
       "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
@@ -4388,6 +4405,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "strftime": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz",
+      "integrity": "sha1-hrFZSYRefeIMDD1p2yt0+3Pk0l4="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.17.4",
     "pg": "6.1.x",
     "request": "2.81.x",
+    "s3-streamlogger": "^1.3.1",
     "tmp": "0.0.33",
     "winston": "^2.4.0",
     "winston-aws-cloudwatch": "^1.6.0"


### PR DESCRIPTION
This switches to the new pattern of putting all job files in a single S3 bucket; also enables writing logs to a file in said S3 bucket.

Corresponding PL changes are here: https://github.com/PrairieLearn/PrairieLearn/pull/886