### PR TITLE
Add Docker image preloading on grader startup

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -5,6 +5,9 @@ properties:
     envVar: MAX_CONCURRENT_JOBS
 
   # Feature enable/disable
+  useDatabase:
+    default: false
+    envVar: USE_DATABASE
   useEc2MetadataService:
     default: true
     envVar: USE_EC2_METADATA_SERVICE
@@ -14,6 +17,9 @@ properties:
   useConsoleLoggingForJobs:
     default: false
     envVar: USE_CONSOLE_LOGGING_FOR_JOBS
+  useImagePreloading:
+    default: false
+    envVar: USE_IMAGE_PRELOADING
 
   # CloudWatch logging
   globalLogGroup:
@@ -47,8 +53,8 @@ properties:
     default: 'postgres'
     envVar: PG_DATABASE
   postgresqlUser:
-    default: 'grader'
+    default: null
     envVar: PG_USER
   postgresqlPassword:
-    default: 'grader_password'
+    default: null
     envVar: PG_PASSWORD

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,8 +1,12 @@
 parent: base
 properties:
+  useDatabase:
+    default: true
   useEc2MetadataService:
     default: true
   useCloudWatchLogging:
+    default: true
+  useImagePreloading:
     default: true
   reportLoad:
     default: true

--- a/lib/pullImages.js
+++ b/lib/pullImages.js
@@ -1,0 +1,55 @@
+const ERR = require('async-stacktrace');
+const async = require('async');
+const Docker = require('dockerode');
+
+const logger = require('./logger');
+const util = require('./util');
+const sqldb = require('./sqldb');
+const sql = require('./sql-loader').loadSqlEquiv(__filename);
+
+module.exports = function(callback) {
+    const docker = new Docker();
+    async.waterfall([
+        (callback) => {
+            logger.info('Pinging docker');
+            docker.ping((err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        (callback) => {
+            sqldb.query(sql.select_recent_images, [], (err, results) => {
+                if (ERR(err, callback)) return;
+                const images = results.rows.map(row => row.external_grading_image);
+                callback(null, images);
+            });
+        },
+        (images, callback) => {
+            async.each(images, (image, callback) => {
+                logger.info(`Pulling latest version of "${image}" image`);
+                const repository = util.parseRepositoryTag(image);
+                const params = {
+                    fromImage: repository.repository,
+                    tag: repository.tag || 'latest'
+                };
+
+                docker.createImage(params, (err, stream) => {
+                    if (ERR(err, callback)) return;
+
+                    docker.modem.followProgress(stream, (err) => {
+                        if (ERR(err, callback)) return;
+                        callback(null);
+                    }, (output) => {
+                        logger.info(output);
+                    });
+                });
+            }, (err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        }
+    ], (err) => {
+        if (ERR(err, callback)) return;
+        callback(null);
+    });
+};

--- a/lib/pullImages.sql
+++ b/lib/pullImages.sql
@@ -1,0 +1,9 @@
+-- BLOCK select_recent_images
+SELECT DISTINCT q.external_grading_image
+FROM grading_jobs AS gj
+JOIN submissions AS s ON (s.id = gj.submission_id)
+JOIN variants AS v ON (v.id = s.variant_id)
+JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
+JOIN questions AS q ON (q.id = aq.question_id)
+WHERE gj.grading_requested_at >= (NOW() - INTERVAL '1 hour');


### PR DESCRIPTION
This PR prevents a grader from receiving jobs until all of the images used in any jobs from the past hour have been loaded on this machine (this will include the image for a job that triggered a scale-out event). This should prevent a job from sitting on a machine that's pulling new images. This won't prevent slowdowns on existing graders when a new course image is pushed by an instructor, but that's almost unavoidable.