### PR TITLE
Tell AWS if the message visibility timeout should change

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -44,6 +44,9 @@ properties:
   queueUrl:
     default: null
     envVar: QUEUE_URL
+  defaultTimeout:
+    default: 30
+    envVar: DEFAULT_TIMEOUT
 
   # Postgres config
   postgresqlHost:

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function handleJob(job, done) {
         s3: new AWS.S3(),
         receivedTime,
         logger,
-        job
+        job,
     };
 
     logger.info(`Running job ${job.jobId}!`);

--- a/lib/receiveFromQueue.js
+++ b/lib/receiveFromQueue.js
@@ -67,10 +67,14 @@ module.exports = function(sqs, queueUrl, receiveCallback, doneCallback) {
         },
         (callback) => {
             const timeout = parsedMessage.timeout || config.defaultTimeout;
+            // Add additional time to account for work that PG has to do:
+            // downloading/uploading files, etc. This wasn't scientifically
+            // chosen at all.
+            const newTimeout = timeout + 10;
             const visibilityParams = {
                 QueueUrl: queueUrl,
                 ReceiptHandle: receiptHandle,
-                VisibilityTimeout: timeout + 10,
+                VisibilityTimeout: newTimeout,
             };
             sqs.changeMessageVisibility(visibilityParams, (err) => {
                 if (ERR(err, callback)) return;


### PR DESCRIPTION
This will prevent messages from being received again if their timeout exceeds the default visibility window of 30s. Adds an additional 10s to account for any work that we have to do (downloading/uploading files, etc.)