### PR TITLE
Skip jobs that were canceled prior to being received

### DIFF
--- a/lib/receiveFromQueue.sql
+++ b/lib/receiveFromQueue.sql
@@ -1,0 +1,5 @@
+-- BLOCK check_job_cancelation
+SELECT
+    (grading_request_canceled_at IS NOT NULL) AS canceled
+FROM grading_jobs
+WHERE id = $grading_job_id;


### PR DESCRIPTION
Tested locally with `MAX_CONCURRENT_JOBS=1 USE_DATABASE=true node index.js` and submitting 3 infinite-looping jobs in rapid succession. The expectation is that the first job will run, the second job will be skipped, and the third job will be run. This is what happens, so this should be working.