### PR TITLE
Allow PG to report times directly to the DB

### DIFF
--- a/lib/timeReporter.js
+++ b/lib/timeReporter.js
@@ -1,0 +1,25 @@
+const ERR = require('async-stacktrace');
+
+const config = require('./config').config;
+const sqldb = require('./sqldb');
+const sql = require('./sql-loader').loadSqlEquiv(__filename);
+
+function reportTime(sqlBlockName) {
+  return function(jobId, time, callback) {
+    if (!config.useDatabase) return callback(null);
+    const params = {
+      job_id: jobId,
+      time,
+    };
+    sqldb.queryOneRow(sql[sqlBlockName], params, (err) => {
+      if (ERR(err, callback)) return;
+      callback(null);
+    });
+  };
+}
+
+module.exports.reportReceivedTime = reportTime('update_job_received_time');
+
+module.exports.reportStartTime = reportTime('update_job_start_time');
+
+module.exports.reportEndTime = reportTime('update_job_end_time');

--- a/lib/timeReporter.js
+++ b/lib/timeReporter.js
@@ -5,15 +5,12 @@ const sqldb = require('./sqldb');
 const sql = require('./sql-loader').loadSqlEquiv(__filename);
 
 function reportTime(sqlBlockName) {
-  return function(jobId, time, callback) {
+  return function(jobId, callback) {
     if (!config.useDatabase) return callback(null);
-    const params = {
-      job_id: jobId,
-      time,
-    };
-    sqldb.queryOneRow(sql[sqlBlockName], params, (err) => {
+    const params = { job_id: jobId };
+    sqldb.queryOneRow(sql[sqlBlockName], params, (err, results) => {
       if (ERR(err, callback)) return;
-      callback(null);
+      callback(null, results.rows[0].time);
     });
   };
 }

--- a/lib/timeReporter.sql
+++ b/lib/timeReporter.sql
@@ -1,0 +1,20 @@
+-- BLOCK update_job_received_time
+UPDATE grading_jobs
+SET
+    grading_received_at = $time
+WHERE
+    id = $job_id;
+
+-- BLOCK update_job_start_time
+UPDATE grading_jobs
+SET
+    grading_started_at = $time
+WHERE
+    id = $job_id;
+
+-- BLOCK update_job_end_time
+UPDATE grading_jobs
+SET
+    grading_finished_at = $time
+WHERE
+    id = $job_id;

--- a/lib/timeReporter.sql
+++ b/lib/timeReporter.sql
@@ -1,20 +1,23 @@
 -- BLOCK update_job_received_time
 UPDATE grading_jobs
 SET
-    grading_received_at = $time
+    grading_received_at = NOW()
 WHERE
-    id = $job_id;
+    id = $job_id
+RETURNING grading_jobs.grading_received_at AS time;
 
 -- BLOCK update_job_start_time
 UPDATE grading_jobs
 SET
-    grading_started_at = $time
+    grading_started_at = NOW()
 WHERE
-    id = $job_id;
+    id = $job_id
+RETURNING grading_jobs.grading_started_at AS time;
 
 -- BLOCK update_job_end_time
 UPDATE grading_jobs
 SET
-    grading_finished_at = $time
+    grading_finished_at = NOW()
 WHERE
-    id = $job_id;
+    id = $job_id
+RETURNING grading_jobs.grading_finished_at AS time;


### PR DESCRIPTION
Tested by disabling webhook reporting in PG and submitting a local job. I then connected to Postgres and manually verified that the times were updated correctly.

Currently this is enabled whenever `USE_DATABASE` is enabled - I don't think we need a separate switch for this?