### PR TITLE
Add health checks for Docker not responding

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,8 +282,8 @@ function runJob(info, callback) {
     const globalJobTimeoutId = setTimeout(() => {
         jobFailed = true;
         healthCheck.flagUnhealthy('Job timeout exceeded; Docker presumed dead.');
-        return callback(new Error(`Job timeout of ${globalJobTimeout} exceeded.`));
-    }, globalJobTimeout);
+        return callback(new Error(`Job timeout of ${globalJobTimeout}s exceeded.`));
+    }, globalJobTimeout * 1000);
 
     logger.info('Launching Docker container to run grading job');
 
@@ -327,6 +327,11 @@ function runJob(info, callback) {
                 });
                 callback(null, container);
             });
+        },
+        (container, callback) => {
+            setTimeout(() => {
+                callback(null, container);
+            }, globalJobTimeout * 1000);
         },
         (container, callback) => {
             container.start((err) => {

--- a/index.js
+++ b/index.js
@@ -329,11 +329,6 @@ function runJob(info, callback) {
             });
         },
         (container, callback) => {
-            setTimeout(() => {
-                callback(null, container);
-            }, globalJobTimeout * 1000);
-        },
-        (container, callback) => {
             container.start((err) => {
                 if (ERR(err, callback)) return;
                 logger.info('Container started!');

--- a/index.js
+++ b/index.js
@@ -281,6 +281,7 @@ function runJob(info, callback) {
     let jobFailed = false;
     const globalJobTimeoutId = setTimeout(() => {
         jobFailed = true;
+        healthCheck.flagUnhealthy('Job timeout exceeded; Docker presumed dead.');
         return callback(new Error(`Job timeout of ${globalJobTimeout} exceeded.`));
     }, globalJobTimeout);
 

--- a/lib/healthCheck.js
+++ b/lib/healthCheck.js
@@ -4,7 +4,14 @@ const Docker = require('dockerode');
 const globalLogger = require('./logger');
 const config = require('./config').config;
 
-/*
+/**
+ * Stores our current status. Once we transition to an unhealthy state, there's
+ * no going back. We'll be killed eventually.
+ */
+let healthy = true;
+let unhealthyReason = null;
+
+/**
  * We have two levels of health checks here:
  *
  * 1) a /ping endpoint that will send a 200 status if we can connect to the
@@ -17,11 +24,8 @@ module.exports.init = function(callback) {
 
     const handler = (req, res) => {
         if (req.url === '/ping') {
-            docker.ping((err) => {
-                const healthy = !err;
-                res.statusCode = healthy ? 200 : 500;
-                res.end(healthy ? 'Healthy' : 'Unhealthy');
-            });
+            res.statusCode = healthy ? 200 : 500;
+            res.end(healthy ? 'Healthy' : `Unhealthy: ${unhealthyReason}`);
         } else {
             res.statusCode = 404;
             res.end('Not found');
@@ -31,8 +35,7 @@ module.exports.init = function(callback) {
     const doHealthCheck = () => {
         docker.ping((err) => {
             if (err) {
-                globalLogger.error('Failed health check: Docker unreachable');
-                process.exit(1);
+                module.exports.flagUnhealthy('Docker unreachable');
             }
             setTimeout(doHealthCheck, config.healthCheckInterval);
         });
@@ -50,4 +53,9 @@ module.exports.init = function(callback) {
             callback(null);
         }
     });
+};
+
+module.exports.flagUnhealthy = function(reason) {
+    healthy = false;
+    unhealthyReason = reason;
 };

--- a/lib/healthCheck.js
+++ b/lib/healthCheck.js
@@ -56,6 +56,7 @@ module.exports.init = function(callback) {
 };
 
 module.exports.flagUnhealthy = function(reason) {
+    globalLogger.error(`A health check failed: ${reason}`);
     healthy = false;
     unhealthyReason = reason;
 };

--- a/lib/receiveFromQueue.js
+++ b/lib/receiveFromQueue.js
@@ -15,7 +15,7 @@ module.exports = function(sqs, queueUrl, receiveCallback, doneCallback) {
     let parsedMessage, jobCanceled, receiptHandle;
     async.series([
         (callback) => {
-            globalLogger.info('Waiting for next job');
+            globalLogger.info('Waiting for next job...');
             async.doUntil((done) => {
                 const params = {
                     MaxNumberOfMessages: 1,
@@ -47,7 +47,7 @@ module.exports = function(sqs, queueUrl, receiveCallback, doneCallback) {
             if (!messageSchema) {
                 fs.readJson(path.join(__dirname, 'messageSchema.json'), (err, data) => {
                     if (ERR(err, (err) => globalLogger.error(err))) {
-                        globalLogger.error('Failed to read message schema; exiting process');
+                        globalLogger.error('Failed to read message schema; exiting process.');
                         process.exit(1);
                     }
                     const ajv = new Ajv();
@@ -100,15 +100,15 @@ module.exports = function(sqs, queueUrl, receiveCallback, doneCallback) {
         (callback) => {
             // Don't execute the job if it was canceled
             if (jobCanceled) {
-                globalLogger.info(`Job ${parsedMessage.jobId} was canceled; skipping job`);
+                globalLogger.info(`Job ${parsedMessage.jobId} was canceled; skipping job.`);
                 return callback(null);
             }
 
             receiveCallback(parsedMessage, (err) => {
-                globalLogger.error('err!');
+                globalLogger.info(`Job ${parsedMessage.jobId} finished successfully.`);
                 callback(err);
             }, () => {
-                globalLogger.info('success!');
+                globalLogger.info(`Job ${parsedMessage.jobId} errored.`);
                 callback(null);
             });
         },
@@ -123,7 +123,6 @@ module.exports = function(sqs, queueUrl, receiveCallback, doneCallback) {
             });
         }
     ], (err) => {
-        globalLogger.info('done!');
         if (ERR(err, doneCallback)) return;
         doneCallback(null);
     });


### PR DESCRIPTION
Untested; putting this up for review/testing by @mwest1066.

This keeps a global "healthy" state that begins at true and will only ever transition to false; once unhealthy, we'll rely on EC2 health checks killing us eventually.

Also adds a health check that fails if a job takes more than 2x job timeout to execute; we'll assume terrible horrible Docker failure in that case.