### PR TITLE
Remove volumes when removing grading containers

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,7 +430,10 @@ function runJob(info, callback) {
             });
         },
         (container, callback) => {
-            container.remove((err) => {
+            container.remove({
+                // Remove any volumes associated with this container
+                v: true,
+            }, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });


### PR DESCRIPTION
Sister commit to https://github.com/PrairieLearn/PrairieLearn/pull/1422. Removes any volumes associated with a container when a container is removed.