### PR TITLE
Fix job logger to work with winston 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # AWS config file
 aws-config.json
+
+# VS Code files
+.vscode

--- a/lib/jobLogger.js
+++ b/lib/jobLogger.js
@@ -25,10 +25,10 @@ module.exports = function(options) {
     ];
 
     if (config.useConsoleLoggingForJobs) {
-        transports.push(new (winston.transports.Console)({timestamp: true, colorize: true}));
+        transports.push(new winston.transports.Console({timestamp: true, colorize: true}));
     }
 
-    const logger = new (winston.Logger)({ transports });
+    const logger = winston.createLogger({ transports });
 
     logger.on('error', (err) => {
         globalLogger.error(`Error sending logs to ${bucket}/${rootKey}/output.log`);


### PR DESCRIPTION
Updates the job logger to work with the new Winston 3 API. Haven't tested yet - still need to deploy to the staging environment.

Fixes #53