### PR TITLE
Add graceful termination on SIGTERM

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ const dockerUtil = require('./lib/dockerUtil');
 const load = require('./lib/load');
 
 let processTerminating = false;
-process.on('SIGTERM', () => {processTerminating = true;});
+process.on('SIGTERM', () => {
+    globalLogger.info('caught SIGTERM, draining jobs to exit...');
+    processTerminating = true;
+});
 
 async.series([
     (callback) => {

--- a/lib/receiveFromQueue.js
+++ b/lib/receiveFromQueue.js
@@ -1,5 +1,3 @@
-const ERR = require('async-stacktrace');
-const async = require('async');
 const fs = require('fs-extra');
 const path = require('path');
 const Ajv = require('ajv');
@@ -9,121 +7,63 @@ const globalLogger = require('./logger');
 const config = require('./config').config;
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
-let messageSchema = null;
+const schemaData = fs.readJsonSync(path.join(__dirname, 'messageSchema.json'));
+const ajv = new Ajv();
+const messageSchema = ajv.compile(schemaData);
 
-module.exports = function(sqs, queueUrl, receiveCallback, doneCallback) {
-    let parsedMessage, jobCanceled, receiptHandle;
-    async.series([
-        (callback) => {
-            globalLogger.info('Waiting for next job...');
-            async.doUntil((done) => {
-                const params = {
-                    MaxNumberOfMessages: 1,
-                    QueueUrl: queueUrl,
-                    WaitTimeSeconds: 20
-                };
-                sqs.receiveMessage(params, (err, data) => {
-                    if (ERR(err, done)) return;
-                    if (!data.Messages) {
-                        return done(null, null);
-                    }
-                    globalLogger.info('Received job!');
-                    try {
-                        parsedMessage = JSON.parse(data.Messages[0].Body);
-                        receiptHandle = data.Messages[0].ReceiptHandle;
-                    } catch (e) {
-                        return done(e);
-                    }
-                    return done(null, parsedMessage);
-                });
-            }, (result, callback) => {
-                callback(null, !!result);
-            }, (err) => {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        (callback) => {
-            if (!messageSchema) {
-                fs.readJson(path.join(__dirname, 'messageSchema.json'), (err, data) => {
-                    if (ERR(err, (err) => globalLogger.error(err))) {
-                        globalLogger.error('Failed to read message schema; exiting process.');
-                        process.exit(1);
-                    }
-                    const ajv = new Ajv();
-                    messageSchema = ajv.compile(data);
-                    return callback(null);
-                });
-            } else {
-                return callback (null);
-            }
-        },
-        (callback) => {
-            const valid = messageSchema(parsedMessage);
-            if (!valid) {
-                globalLogger.error(messageSchema.errors);
-                return callback(new Error('Message did not match schema.'));
-            } else {
-                return callback(null);
-            }
-        },
-        (callback) => {
-            const timeout = parsedMessage.timeout || config.defaultTimeout;
-            // Add additional time to account for work that PG has to do:
-            // downloading/uploading files, etc. This wasn't scientifically
-            // chosen at all.
-            const newTimeout = timeout + 10;
-            const visibilityParams = {
-                QueueUrl: queueUrl,
-                ReceiptHandle: receiptHandle,
-                VisibilityTimeout: newTimeout,
-            };
-            sqs.changeMessageVisibility(visibilityParams, (err) => {
-                if (ERR(err, callback)) return;
-                return callback(null);
-            });
-        },
-        (callback) => {
-            // If we're configured to use the database, ensure that this job
-            // wasn't canceled in the time since job submission
-            if (!config.useDatabase) return callback(null);
+module.exports = {};
 
-            const params = {
-                grading_job_id: parsedMessage.jobId,
-            };
-            sqldb.queryOneRow(sql.check_job_cancelation, params, (err, result) => {
-                if (ERR(err, callback)) return;
-                jobCanceled = result.rows[0].canceled;
-                callback(null);
-            });
-        },
-        (callback) => {
-            // Don't execute the job if it was canceled
-            if (jobCanceled) {
-                globalLogger.info(`Job ${parsedMessage.jobId} was canceled; skipping job.`);
-                return callback(null);
-            }
+module.exports.receive = async function(sqs, queueUrl) {
+    let params;
 
-            receiveCallback(parsedMessage, (err) => {
-                globalLogger.info(`Job ${parsedMessage.jobId} errored.`);
-                callback(err);
-            }, () => {
-                globalLogger.info(`Job ${parsedMessage.jobId} finished successfully.`);
-                callback(null);
-            });
-        },
-        (callback) => {
-            const deleteParams = {
-                QueueUrl: queueUrl,
-                ReceiptHandle: receiptHandle
-            };
-            sqs.deleteMessage(deleteParams, (err) => {
-                if (ERR(err, callback)) return;
-                return callback(null);
-            });
-        }
-    ], (err) => {
-        if (ERR(err, doneCallback)) return;
-        doneCallback(null);
-    });
+    params = {
+        MaxNumberOfMessages: 1,
+        QueueUrl: queueUrl,
+        WaitTimeSeconds: 20
+    };
+    const data = await sqs.receiveMessage(params).promise();
+    if (!data.Messages) return;
+
+    globalLogger.info('Received job!');
+    const parsedMessage = JSON.parse(data.Messages[0].Body);
+    const receiptHandle = data.Messages[0].ReceiptHandle;
+
+    const valid = messageSchema(parsedMessage);
+    if (!valid) {
+        globalLogger.error('Message did not match schema.', messageSchema.errors);
+        return;
+    }
+
+    const timeout = parsedMessage.timeout || config.defaultTimeout;
+    // Add additional time to account for work that PG has to do:
+    // downloading/uploading files, etc. This wasn't scientifically
+    // chosen at all.
+    const newTimeout = timeout + 10;
+    params = {
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+        VisibilityTimeout: newTimeout,
+    };
+    await sqs.changeMessageVisibility(params).promise();
+
+    // If we're configured to use the database, ensure that this job
+    // wasn't canceled in the time since job submission
+    params = {
+        grading_job_id: parsedMessage.jobId,
+    };
+    const result = await sqldb.queryOneRowAsync(sql.check_job_cancelation, params);
+    if (result.rows[0].canceled) {
+        globalLogger.info(`Job ${parsedMessage.jobId} was canceled; skipping job.`);
+        return;
+    }
+
+    return {parsedMessage, receiptHandle};
+};
+
+module.exports.delete = async function(sqs, queueUrl, receiptHandle) {
+    const deleteParams = {
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle
+    };
+    await sqs.deleteMessage(deleteParams).promise();
 };

--- a/lib/receiveFromQueue.js
+++ b/lib/receiveFromQueue.js
@@ -25,16 +25,16 @@ module.exports.receive = async function(sqs, queueUrl) {
     if (!data.Messages) return;
 
     globalLogger.info('Received job!');
-    const parsedMessage = JSON.parse(data.Messages[0].Body);
+    const job = JSON.parse(data.Messages[0].Body);
     const receiptHandle = data.Messages[0].ReceiptHandle;
 
-    const valid = messageSchema(parsedMessage);
+    const valid = messageSchema(job);
     if (!valid) {
         globalLogger.error('Message did not match schema.', messageSchema.errors);
         return;
     }
 
-    const timeout = parsedMessage.timeout || config.defaultTimeout;
+    const timeout = job.timeout || config.defaultTimeout;
     // Add additional time to account for work that PG has to do:
     // downloading/uploading files, etc. This wasn't scientifically
     // chosen at all.
@@ -49,15 +49,15 @@ module.exports.receive = async function(sqs, queueUrl) {
     // If we're configured to use the database, ensure that this job
     // wasn't canceled in the time since job submission
     params = {
-        grading_job_id: parsedMessage.jobId,
+        grading_job_id: job.jobId,
     };
     const result = await sqldb.queryOneRowAsync(sql.check_job_cancelation, params);
     if (result.rows[0].canceled) {
-        globalLogger.info(`Job ${parsedMessage.jobId} was canceled; skipping job.`);
+        globalLogger.info(`Job ${job.jobId} was canceled; skipping job.`);
         return;
     }
 
-    return {parsedMessage, receiptHandle};
+    return {job, receiptHandle};
 };
 
 module.exports.delete = async function(sqs, queueUrl, receiptHandle) {


### PR DESCRIPTION
This PR is an alternative to handling the TERMINATING lifecycle event. The TERMINATING lifecycle event is complicated, because you need to set up an SNS topic to receive the event, which then calls a Lambda function, which then pings a webhook on the grader. At any rate, that’s the simplest setup I could find for handling TERMINATING. You can also have SNS send webhook events directly, but then graders need to register their webhooks dynamically with SNS and handle notification setup requests.

As an alternative, this PR uses the fact that EC2 termination does a proper shutdown of the VM. Systemd terminates services by sending them a SIGTERM. In this PR we catch this SIGTERM and then wait for any current jobs to finish grading before we exit. We also wait for any SQS requests to finish, which means that we can take up to 20 seconds to exit even when we have no jobs processing, due to SQS long polling. We could detect this and force-exit, but I thought it wasn’t worth the extra complexity.

In the systemd unit configuration we will need to set `TimeoutStopSec` to a large value (maybe 600 seconds) to give us enough time to process any reasonable jobs. If we have a really long job then we’ll still just kill it, because systemd does a SIGKILL if we exceed this timeout.

As part of this PR I rewrote `lib/receiveFromQueue` and the main loop in `index.js` to use async/await. I didn’t want to make such an invasive change, but the control flow changes were reasonably complicated (`async.times()` calling `async.while()`, calling various nested callbacks) that I thought it was actually safer to rewrite with a/a.